### PR TITLE
Nested Framework HandySwift

### DIFF
--- a/CSVImporter.xcodeproj/project.pbxproj
+++ b/CSVImporter.xcodeproj/project.pbxproj
@@ -9,12 +9,9 @@
 /* Begin PBXBuildFile section */
 		82239F4B1C4AF70500627674 /* CSVImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 82239F4A1C4AF70500627674 /* CSVImporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		82239F521C4AF70500627674 /* CSVImporter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82239F471C4AF70500627674 /* CSVImporter.framework */; };
-		82239F6A1C4AF9AE00627674 /* HandySwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82239F681C4AF9AE00627674 /* HandySwift.framework */; };
 		82239F711C4AFAA800627674 /* CSVImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82239F701C4AFAA800627674 /* CSVImporter.swift */; };
 		82239F811C4AFAFF00627674 /* CSVImporter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82239F771C4AFAFF00627674 /* CSVImporter.framework */; };
 		82239F9D1C4AFB1000627674 /* CSVImporter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82239F931C4AFB1000627674 /* CSVImporter.framework */; };
-		82239FAB1C4AFB2D00627674 /* HandySwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82239F6C1C4AFA0F00627674 /* HandySwift.framework */; };
-		82239FAD1C4AFB3200627674 /* HandySwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82239F6E1C4AFA1E00627674 /* HandySwift.framework */; };
 		82239FAE1C4AFB3500627674 /* CSVImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82239F701C4AFAA800627674 /* CSVImporter.swift */; };
 		82239FAF1C4AFB3600627674 /* CSVImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82239F701C4AFAA800627674 /* CSVImporter.swift */; };
 		82239FB01C4AFB3900627674 /* CSVImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 82239F4A1C4AF70500627674 /* CSVImporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -241,7 +238,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				82239F6A1C4AF9AE00627674 /* HandySwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -259,7 +255,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				82239FAB1C4AFB2D00627674 /* HandySwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -277,7 +272,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				82239FAD1C4AFB3200627674 /* HandySwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -538,7 +532,6 @@
 				82239F431C4AF70500627674 /* Frameworks */,
 				82239F441C4AF70500627674 /* Headers */,
 				82239F451C4AF70500627674 /* Resources */,
-				82239F6F1C4AFA4900627674 /* Copy Frameworks */,
 				828348681CA6E1F100DC4C26 /* Run Swift Linter */,
 			);
 			buildRules = (
@@ -578,7 +571,6 @@
 				82239F731C4AFAFF00627674 /* Frameworks */,
 				82239F741C4AFAFF00627674 /* Headers */,
 				82239F751C4AFAFF00627674 /* Resources */,
-				82239FB21C4AFB9200627674 /* Copy Frameworks */,
 				828348691CA6E1FD00DC4C26 /* Run Swift Linter */,
 			);
 			buildRules = (
@@ -839,43 +831,12 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		82239F6F1C4AFA4900627674 /* Copy Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/HandySwift.framework",
-			);
-			name = "Copy Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-		82239FB21C4AFB9200627674 /* Copy Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/tvOS/HandySwift.framework",
-			);
-			name = "Copy Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
 		82239FB31C4AFB9700627674 /* Copy Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/Mac/HandySwift.framework",
 			);
 			name = "Copy Frameworks";
 			outputPaths = (


### PR DESCRIPTION
Hi,

we're using your CSVImporter Framework with Carthage. At first glance this works fine, but then we tried to submit our App to the AppStore (actually a Testflight build) and got severals errors regarding nested Frameworks.

The problem is the embedded HandySwift framework inside the CSVImporter framework. This results in two HandySwift.frameworks inside the final App Archive. 

We had this issue with some others Frameworks before. The solution (which is recommended from Carthage itself) is not (!) to embed any dependencies of a Framework, but only embed these dependencies at top-most level (i.e. the actual App). This PR removes the nested Framework HandySwift, builds fine and could be submitted to the AppStore.

The actual fetching of the HandySwift Framework is still triggered by the CSVImporter Framework's Cartfile, but you have to add the HandySwift Framework to your App-Project by hand.