### PR TITLE
Replace multiple instances of delimiterQuoteDelimiter

### DIFF
--- a/Sources/Code/CSVImporter.swift
+++ b/Sources/Code/CSVImporter.swift
@@ -269,7 +269,10 @@ public class CSVImporter<T> {
     ///   - line: The line to read values from.
     /// - Returns: An array of values found in line.
     func readValuesInLine(_ line: String) -> [String] {
-        var correctedLine = line.replacingOccurrences(of: delimiterQuoteDelimiter, with: delimiterDelimiter)
+        var correctedLine = line
+        while correctedLine.contains(delimiterQuoteDelimiter) {
+            correctedLine = correctedLine.replacingOccurrences(of: delimiterQuoteDelimiter, with: delimiterDelimiter)
+        }
 
         if correctedLine.hasPrefix(quoteDelimiter) {
             correctedLine = correctedLine.substring(from: correctedLine.characters.index(correctedLine.startIndex, offsetBy: 2))


### PR DESCRIPTION
I had an issue where I had 2 columns next to each other in a CSV that were empty strings. The first was processed fine but the 2nd ended up as a double quote character. This PR appears to fix the problem.

Example CSV line:
"21 Feb 2017","DIRECT DEBIT PAYMENT","","","£104.30"