### PR TITLE
Compact Mapping and Error Handling

### DIFF
--- a/Frameworks/CSVImporter/CSVImporter.swift
+++ b/Frameworks/CSVImporter/CSVImporter.swift
@@ -200,7 +200,7 @@ public class CSVImporter<T> {
     ///   - compactRecordMapper: A closure to map the dictionary data interpreted from a line to your data structure. Nil values are omitted from results.
     /// - Returns: `self` to enable consecutive method calls (e.g. `importer.startImportingRecords {...}.onProgress {...}`).
     public func startImportingRecords(
-        structure structureClosure: @escaping (_ headerValues: [String]) -> Void,
+        structure structureClosure: @escaping (_ headerValues: [String]) throws -> Void,
         compactRecordMapper closure: @escaping (_ recordValues: [String: String]) throws -> T?
     ) -> Self {
         workDispatchQueue.async {
@@ -211,7 +211,7 @@ public class CSVImporter<T> {
                 try self.importLines { valuesInLine in
                     guard let titles = recordStructure else {
                         recordStructure = valuesInLine
-                        structureClosure(valuesInLine)
+                        try structureClosure(valuesInLine)
                         return
                     }
                     let structuredValues = [String: String](uniqueKeysWithValues: zip(titles, valuesInLine))
@@ -237,7 +237,7 @@ public class CSVImporter<T> {
     ///   - recordMapper: A closure to map the dictionary data interpreted from a line to your data structure.
     /// - Returns: `self` to enable consecutive method calls (e.g. `importer.startImportingRecords {...}.onProgress {...}`).
     public func startImportingRecords(
-        structure structureClosure: @escaping (_ headerValues: [String]) -> Void,
+        structure structureClosure: @escaping (_ headerValues: [String]) throws -> Void,
         recordMapper closure: @escaping (_ recordValues: [String: String]) throws -> T
     ) -> Self {
         workDispatchQueue.async {
@@ -248,7 +248,7 @@ public class CSVImporter<T> {
                 try self.importLines { valuesInLine in
                     guard let titles = recordStructure else {
                         recordStructure = valuesInLine
-                        structureClosure(valuesInLine)
+                        try structureClosure(valuesInLine)
                         return
                     }
                     let structuredValues = [String: String](uniqueKeysWithValues: zip(titles, valuesInLine))
@@ -272,7 +272,9 @@ public class CSVImporter<T> {
     /// - Parameters:
     ///   - compactMapper: A closure to map the data received in a line to your data structure. Nil values are omitted from results.
     /// - Returns: The imported records array.
-    public func importRecords(compactMapper closure: @escaping (_ recordValues: [String]) throws -> T?) rethrows -> [T] {
+    public func importRecords(
+        compactMapper closure: @escaping (_ recordValues: [String]) throws -> T?
+    ) rethrows -> [T] {
         var importedRecords = [T]()
 
         try self.importLines { valuesInLine in
@@ -292,7 +294,9 @@ public class CSVImporter<T> {
     /// - Parameters:
     ///   - mapper: A closure to map the data received in a line to your data structure.
     /// - Returns: The imported records array.
-    public func importRecords(mapper closure: @escaping (_ recordValues: [String]) throws -> T) rethrows -> [T] {
+    public func importRecords(
+        mapper closure: @escaping (_ recordValues: [String]) throws -> T
+    ) rethrows -> [T] {
         var importedRecords = [T]()
 
         try self.importLines { valuesInLine in

--- a/Frameworks/CSVImporter/CSVImporter.swift
+++ b/Frameworks/CSVImporter/CSVImporter.swift
@@ -311,7 +311,7 @@ public class CSVImporter<T> {
     ///   - compactRecordMapper: A closure to map the dictionary data interpreted from a line to your data structure. Nil values are omitted from results.
     /// - Returns: The imported records array.
     public func importRecords(
-        structure structureClosure: @escaping (_ headerValues: [String]) -> Void,
+        structure structureClosure: @escaping (_ headerValues: [String]) throws -> Void,
         compactRecordMapper closure: @escaping (_ recordValues: [String: String]) throws -> T?
     ) rethrows -> [T] {
         var recordStructure: [String]?
@@ -320,7 +320,7 @@ public class CSVImporter<T> {
         try self.importLines { valuesInLine in
             guard let titles = recordStructure else {
                 recordStructure = valuesInLine
-                structureClosure(valuesInLine)
+                try structureClosure(valuesInLine)
                 return
             }
             let structuredValues = [String: String](uniqueKeysWithValues: zip(titles, valuesInLine))
@@ -342,7 +342,7 @@ public class CSVImporter<T> {
     ///   - recordMapper: A closure to map the dictionary data interpreted from a line to your data structure.
     /// - Returns: The imported records array.
     public func importRecords(
-        structure structureClosure: @escaping (_ headerValues: [String]) -> Void,
+        structure structureClosure: @escaping (_ headerValues: [String]) throws -> Void,
         recordMapper closure: @escaping (_ recordValues: [String: String]) throws -> T
     ) rethrows -> [T] {
         var recordStructure: [String]?
@@ -351,7 +351,7 @@ public class CSVImporter<T> {
         try self.importLines { valuesInLine in
             guard let titles = recordStructure else {
                 recordStructure = valuesInLine
-                structureClosure(valuesInLine)
+                try structureClosure(valuesInLine)
                 return
             }
             let structuredValues = [String: String](uniqueKeysWithValues: zip(titles, valuesInLine))

--- a/Frameworks/CSVImporter/FileSource.swift
+++ b/Frameworks/CSVImporter/FileSource.swift
@@ -19,13 +19,14 @@ class FileSource: Source {
         self.lineEnding = lineEnding
     }
 
-    func forEach(_ closure: (String) -> Void) {
+    func forEach(_ closure: (String) throws -> Void) rethrows {
         if lineEnding == .unknown {
             lineEnding = lineEndingForFile()
         }
 
+        // Throw here?
         guard let csvStreamReader = textFile.streamReader(lineEnding: lineEnding, chunkSize: chunkSize) else { return }
-        csvStreamReader.forEach(closure)
+        try csvStreamReader.forEach(closure)
     }
 
     /// Determines the line ending for the CSV file

--- a/Frameworks/CSVImporter/FileSource.swift
+++ b/Frameworks/CSVImporter/FileSource.swift
@@ -24,7 +24,6 @@ class FileSource: Source {
             lineEnding = lineEndingForFile()
         }
 
-        // Throw here?
         guard let csvStreamReader = textFile.streamReader(lineEnding: lineEnding, chunkSize: chunkSize) else { return }
         try csvStreamReader.forEach(closure)
     }

--- a/Frameworks/CSVImporter/Source.swift
+++ b/Frameworks/CSVImporter/Source.swift
@@ -11,5 +11,5 @@ import Foundation
 let chunkSize = 4_096
 
 protocol Source {
-    func forEach(_ closure: (String) -> Void)
+    func forEach(_ closure: (String) throws -> Void) rethrows
 }

--- a/Frameworks/CSVImporter/StringSource.swift
+++ b/Frameworks/CSVImporter/StringSource.swift
@@ -29,7 +29,7 @@ class StringSource: Source {
         lines = contentString.components(separatedBy: correctedLineEnding.rawValue)
     }
 
-    func forEach(_ closure: (String) -> Void) {
-        lines.forEach(closure)
+    func forEach(_ closure: (String) throws -> Void) rethrows {
+        try lines.forEach(closure)
     }
 }


### PR DESCRIPTION
## Proposed Changes
  - Adds compactMapping functions to help when deserializing CSV to model objects. This allows an application to return a nil value when mapping from `[String]` to `T` if their application has deemed the data invalid.
  - Adopts a more Swift-like error handling approach when mapping values. This is based on how `map(_:)` and `compactMap(_:)` are built in the Swift Standard Library. These changes will allow errors to be thrown in the mapping closures, but shouldn't require existing users of this framework to update how they're currently using this framework.
  - Removed a dependency that did not appear to be used.

I'm having trouble getting the tests to run on my machine so I'm currently unable to test this or write new tests. I tried setting up Carthage by running `carthage update` but the build always fails on `HandySwift tvOS` or `HandySwift iOS`.

Do you have any suggestions on how to get that fixed up? I wouldn't want this to get merged until I've been able to validate this.